### PR TITLE
Adding the allowed modification of resizing legend

### DIFF
--- a/v1/ottp_circuitdata_schema.json
+++ b/v1/ottp_circuitdata_schema.json
@@ -1220,6 +1220,9 @@
                         },
                         "add_tear_drops": {
                           "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/add_tear_drops"
+                        },
+                        "resize_legend": {
+                          "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/resize_legend"
                         }
                       },
                       "aliases": "",
@@ -1920,6 +1923,9 @@
                         },
                         "add_tear_drops": {
                           "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/add_tear_drops"
+                        },
+                        "resize_legend": {
+                          "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/resize_legend"
                         }
                       }
                     }
@@ -3204,6 +3210,13 @@
                             "type": "boolean",
                             "uniqueItems": true
                           }
+                        },
+                        "resize_legend": {
+                          "type": "array",
+                          "items": {
+                            "type": "boolean",
+                            "uniqueItems": true
+                          }
                         }
                       }
                     }
@@ -3882,6 +3895,9 @@
                         },
                         "add_tear_drops": {
                           "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/add_tear_drops"
+                        },
+                        "resize_legend": {
+                          "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/allowed_modifications/resize_legend"
                         }
                       }
                     }

--- a/v1/ottp_circuitdata_schema_definitions.json
+++ b/v1/ottp_circuitdata_schema_definitions.json
@@ -1211,6 +1211,11 @@
           "type": "boolean",
           "uom": null,
           "description": "Adding Tear Drops allowed"
+        },
+        "resize_legend": {
+          "type": "boolean",
+          "uom": null,
+          "description": "Resizing the legend to fit is allowed"
         }
       },
       "additional_requirements": {


### PR DESCRIPTION
This adds the allowed modification to let both specifications, profiles and capabilities set that legend can be resized to match the rest of the files