### PR TITLE
Added minimum_acceptable_annular_ring and {

### DIFF
--- a/v1/ottp_circuitdata_schema.json
+++ b/v1/ottp_circuitdata_schema.json
@@ -1182,6 +1182,12 @@
                           "minimum_designed_annular_ring": {
                             "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/minimum_designed_annular_ring"
                           },
+                          "minimum_acceptable_annular_ring": {
+                            "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/minimum_acceptable_annular_ring"
+                          },
+                          "modify_via_diameter_allowed": {
+                            "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/modify_via_diameter_allowed"
+                          },
                           "press_fit": {
                             "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/press_fit"
                           },
@@ -1905,6 +1911,9 @@
                           },
                           "positive_etchback": {
                             "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/positive_etchback"
+                          },
+                          "modify_via_diameter_allowed": {
+                            "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/modify_via_diameter_allowed"
                           }
                         }
                       }
@@ -3176,6 +3185,13 @@
                               "type": "boolean",
                               "uniqueItems": true
                             }
+                          },
+                          "modify_via_diameter_allowed": {
+                            "type": "array",
+                            "items": {
+                              "type": "boolean",
+                              "uniqueItems": true
+                            }
                           }
                         }
                       }
@@ -3877,6 +3893,9 @@
                           },
                           "positive_etchback": {
                             "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/positive_etchback"
+                          },
+                          "modify_via_diameter_allowed": {
+                            "$ref": "ottp_circuitdata_schema_definitions.json#/definitions/elements/holes/modify_via_diameter_allowed"
                           }
                         }
                       }
@@ -5200,6 +5219,22 @@
                         "maxItems": 2,
                         "items": {
                           "type": "number",
+                          "uniqueItems": true
+                        }
+                      },
+                      "minimum_acceptable_annular_ring": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "type": "number",
+                          "uniqueItems": true
+                        }
+                      },
+                      "modify_via_diameter_allowed": {
+                        "type": "array",
+                        "items": {
+                          "type": "boolean",
                           "uniqueItems": true
                         }
                       },

--- a/v1/ottp_circuitdata_schema_definitions.json
+++ b/v1/ottp_circuitdata_schema_definitions.json
@@ -1161,6 +1161,16 @@
           "uom": ["um"],
           "description": "The minimum designed annular ring"
         },
+        "minimum_acceptable_annular_ring": {
+          "type": "number",
+          "uom": ["um"],
+          "description": "The minimum acceptable annular ring"
+        },
+        "modify_via_diameter_allowed": {
+          "type": "boolean",
+          "uom": null,
+          "description": "Changes to the diameter of the via is allowed to meet the minimum annular ring requirement"
+        },
         "press_fit": {
           "type": "boolean",
           "uom": null,


### PR DESCRIPTION
As discussed in [https://www.circuitdata.org/t/x1z5lk/annular-ring](https://www.circuitdata.org/t/x1z5lk/annular-ring) both `minimum_acceptable_annular_ring` and `modify_via_diameter_allowed` is added to:

- Specifications
- Profiles
- Capabilities 