### PR TITLE
Changed IPC 4761

### DIFF
--- a/Howto.md
+++ b/Howto.md
@@ -29,7 +29,7 @@
 * [Hard gold edge connectors](#hard-gold-edge-connectors)
 * [Markings](#markings)
 * [Standards](#standards)
-* [](#)
+* [IPC 4761](#ipc-4761)
 * [](#)
 
 
@@ -168,3 +168,14 @@ Placed in the "configuration" part, this describes the markings needed. Generall
 Aliases:
 ### as a specification
 Placed in the "configuration" part, this describes the standards that the finished product needs to be comply with. Check out [this](/Products.md#standards) for potential standards. Please note that if you want to have Halogen Free material, you can add "iec_61249-2-21" to the required standard
+
+## IPC 4761
+Aliases: "via protection"
+### as a specification
+Type I: "Tended single or double sided". Soldermask material is dryfilm. Hole "filled" must be with "soldermask".
+Type II: "Tended and covered single or double sided". Soldermask material is dryfilm. Hole "filled" must be with "soldermask". Hole "covered" is true
+Type III: "Plugged single or double sided". Hole "filled" must with be with "soldermask".
+Type IV: "Plugged and covered single or double sided". Hole "filled" must with be with "soldermask". Hole "covered" is true
+Type V: "Filled (fully plugged)". Hole "filled" must with be with "soldermask".
+Type VI: "Filled and covered single or double sided". Hole "filled" must with be with "resin". Hole "covered" is true
+Type VII: "Filled and capped". Hole "filled" must with be with "resin". Hole "covered" is true. Hole "capped" is true.

--- a/Products.md
+++ b/Products.md
@@ -155,7 +155,6 @@ Potential values are:
   * Potential attributes:
     * number_of_holes ( type is "integer". Describes the number of holes in the process )
     * hole_type ( type is "string". Describes the type of hole. Choices are "through", "blind", "buried", "back_drill", "via")
-    * plated ( type is "boolean". True to indicate plated holes )
     * finished_size ( type is "number". The finished size of the holes in micrometers )
     * tool_size ( type is "number". The size of the tool to be used in micrometers )
     * layer_start ( type is "string". Must refer to the name of a layer in the layers section )
@@ -164,12 +163,14 @@ Potential values are:
     * method ( type is "string". How the via is made. Can be either "routing, "drilling" or "laser", where default is "drilling" )
     * minimum_designed_annular_ring ( type is "number". The minimum designed annular ring in micrometers )
     * press_fit ( type is "boolean". True if the holes are for press fit )
-    * copper_filled ( type is "boolean". True if the holes are to be copper filled )
+    * plated ( type is "boolean". True to indicate plated holes )
+    * capped ( type is "boolean". True to indicate capped / overplated holes )
+    * filled ( type is "string", potential values are "copper", "resin", "soldermask")
+    * covered (type is "boolean". True to indicate that the hole is to be covered with soldermask )
     * staggered ( type is "boolean". True if the holes are staggered )
     * stacked ( type is "boolean". True if the holes are staggered )
     * alivh ( type is "boolean". True if ALIVH holes )
     * castellated ( type is "boolean". True if plated half holes )
-    * protection ( type is "string". According to IPC-4761. Choices are "1", "2", "3", "4a", "4b", "5", "6a", "6b")
 
 ## Metrics
 The "metrics" element type is an "object" and can have the following sub-objects:

--- a/Profile_structure_table
+++ b/Profile_structure_table
@@ -33,21 +33,22 @@
 | | | | | process_attributes | | | | | |
 | | | | | | number_of_holes | | | | |
 | | | | | | type | | | | |
-| | | | | | plated | | | | |
 | | | | | | finished_size | | | | |
 | | | | | | tool_size | | | | |
 | | | | | | layer_start | | | | |
 | | | | | | layer_stop | | | | |
 | | | | | | depth | | | | |
 | | | | | | method | | | | |
-| | | | | | | minimum_designed_annular_ring | | | | |
-| | | | | | | press_fit | | | | |
-| | | | | | | copper_filled | | | | |
-| | | | | | | stacked | | | | |
-| | | | | | | staggered | | | | |
-| | | | | | | alivh | | | | |
-| | | | | | | castellated | | | | |
-| | | | | | | protection | | | | |
+| | | | | | minimum_designed_annular_ring | | | | |
+| | | | | | press_fit | | | | |
+| | | | | | plated | | | | |
+| | | | | | capped | | | | |
+| | | | | | filled | | | | |
+| | | | | | covered | | | | |
+| | | | | | stacked | | | | |
+| | | | | | staggered | | | | |
+| | | | | | alivh | | | | |
+| | | | | | castellated | | | | |
 | | | | metrics | | | | | | | |
 | | | | | board | | | | | | |
 | | | | | | size_x | | | | | |

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -110,7 +110,6 @@
               "type": "string",
               "enum": ["through", "blind", "buried", "back_drill", "via"]
             },
-            "plated": { "type": "boolean" },
             "finished_size": { "type": "number"},
             "finished_size": { "type": "number"},
             "layer_start": { "type": "string" },
@@ -122,15 +121,17 @@
             },
             "minimum_designed_annular_ring": { "type": "number"},
             "press_fit": { "type": "boolean" },
-            "copper_filled": { "type": "boolean" },
+            "plated": { "type": "boolean" },
+            "capped": { "type": "boolean" },
+            "filled": {
+              "type": "string",
+              "enum": ["copper", "resin", "soldermask"]
+            },
+            "covered": { "type": "boolean" },
             "staggered": { "type": "boolean" },
             "stacked": { "type": "boolean" },
             "alivh": { "type": "boolean" },
-            "castellated": { "type": "boolean" },
-            "protection": {
-              "type": "string",
-              "enum": ["1", "2", "3", "4a", "4b", "5", "6a", "6b"]
-            }
+            "castellated": { "type": "boolean" }
           }
         }
       }

--- a/schema/v1/ottp_circuitdata_schema_profiles_and_capabilities.json
+++ b/schema/v1/ottp_circuitdata_schema_profiles_and_capabilities.json
@@ -112,18 +112,19 @@
                 "additionalProperties": false,
                 "required": [],
                 "properties": {
-                  "plated": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "tool_size": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "depth": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "method": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "minimum_designed_annular_ring": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "press_fit": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
-                  "copper_filled": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
+                  "plated": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
+                  "capped": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
+                  "filled": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
+                  "covered": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "staggered": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "stacked": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
                   "alivh": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
-                  "castellated": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" },
-                  "protection": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" }
+                  "castellated": { "$ref": "ottp_circuitdata_schema_generics.json#/profile_capability_layer_subelement" }
                 }
               }
             }


### PR DESCRIPTION
Changed the process function "holes" to better facilitate IPC 4761 demands.
- Removed "protection"
- Changed "copper_filled" to "filled" and changed type to string. Choices are "copper", "resin" and "soldermask"
- Added boolean type "capped"
- Added boolean type "covered"