### PR TITLE
Wrap layer_attributes in an object definition

### DIFF
--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -71,21 +71,25 @@
         },
         "coverage": { "type": "number" },
         "layer_attributes": {
-          "minimum_track_width": { "type": "number" },
-          "minimum_spacing_width": { "type": "number" },
-          "conductive_function": {
-            "type": "string",
-            "enum": ["signal", "plane", "mixed"]
-          },
-          "polarity": {
-             "type": "string",
-             "enum": ["positive", "negative"]
-          },
-          "color": { "type": "string" },
-          "allow_touchups": { "type": "boolean" },
-          "placement": {
-             "type": "string",
-             "enum": ["selective_pads", "edge_connectors"]
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "minimum_track_width": { "type": "number" },
+            "minimum_spacing_width": { "type": "number" },
+            "conductive_function": {
+              "type": "string",
+              "enum": ["signal", "plane", "mixed"]
+            },
+            "polarity": {
+              "type": "string",
+              "enum": ["positive", "negative"]
+            },
+            "color": { "type": "string" },
+            "allow_touchups": { "type": "boolean" },
+            "placement": {
+              "type": "string",
+              "enum": ["selective_pads", "edge_connectors"]
+            }
           }
         }
       }


### PR DESCRIPTION
Why: So that it is validated as an object.

This was discussed in https://www.circuitdata.org/t/q5jfqs/layer_attributes-schema-issue