### PR TITLE
Adding UUID to layers in both schema and documentation

### DIFF
--- a/Products.md
+++ b/Products.md
@@ -51,6 +51,7 @@ Potential tags are:
 | Tags          | Description           | [Type](/README.md#about-types-and-how-to-use-them) | Uom | Required |
 |:------------- |:----------------------|:----------------------------------------:|:---:|:--------:|
 | order         | Order of the layer as seen in a cross section and counted from above | integer | None | Yes |
+| uuid          | An unique identifier for the layer | string | None | No |
 | name          | A given name for the layer. Must be unique amongst the layers. Can be any string without spaces | string | None | Yes |
 | function      | The function of layer. [See the list of potential functions below](#layer-functions-and-their-attributes) | string | None | Yes |
 | flexible      | True or false to indicate if this layer is flexible or not | boolean | None | No - default is "False" |

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -33,6 +33,7 @@
       "additionalProperties": false,
       "properties": {
         "order": { "type": "integer" },
+        "uuid": { "type": "string" },
         "name": { "type": "string" },
         "function" : {
           "type": "string",


### PR DESCRIPTION
This adds an unique identifier to layers, so that they are easier to compare to each other across multiple specifications.