### PR TITLE
Add back solder_paste as a layer function

### DIFF
--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -410,7 +410,6 @@
             "order",
             "name",
             "function",
-            "sections",
             "materials"
           ],
           "additionalProperties": false,
@@ -419,7 +418,6 @@
             "uuid": { "type": "string" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["solder_paste"] },
-            "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
             "materials": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
           }
         }

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -403,6 +403,30 @@
               }
             }
           }
+        },
+        {
+          "type": "object",
+          "required": [
+            "order",
+            "name",
+            "function",
+            "sections",
+            "materials"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "order": { "type": "integer" },
+            "uuid": { "type": "string" },
+            "name": { "type": "string" },
+            "function": { "type": "string", "enum": ["solder_paste"] },
+            "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
+            "flexible": { "type": "boolean" },
+            "materials": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
+            "thickness": { "type": "number" },
+            "tolerance_minus": { "type": "number" },
+            "tolerance_plus": { "type": "number" },
+            "coverage": { "type": "number" }
+          }
         }
       ]
     }

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -420,12 +420,7 @@
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["solder_paste"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
-            "flexible": { "type": "boolean" },
-            "materials": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
-            "thickness": { "type": "number" },
-            "tolerance_minus": { "type": "number" },
-            "tolerance_plus": { "type": "number" },
-            "coverage": { "type": "number" }
+            "materials": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
           }
         }
       ]


### PR DESCRIPTION
This was accidentally removed in the previous PR.

Can someone check the attributes make sense for this function. Please check the attributes that make sense and I can remove any unchecked attributes (I have prechecked the required attributes for each layer):
- [x] order
- [x] uuid
- [x] name
- [x] function
- [ ] sections
- [x] materials

Removed after discussion with Andreas:
- [ ] flexible
- [ ] thickness
- [ ] tolerance_minus
- [ ] tolerance_plus
- [ ] coverage
