### PR TITLE
Use UUID instead of name for internal references

### DIFF
--- a/Products.md
+++ b/Products.md
@@ -51,7 +51,7 @@ Potential tags are:
 | Tags          | Description           | [Type](/README.md#about-types-and-how-to-use-them) | Uom | Required |
 |:------------- |:----------------------|:----------------------------------------:|:---:|:--------:|
 | order         | Order of the layer as seen in a cross section and counted from above | integer | None | Yes |
-| uuid          | An unique identifier for the layer | string | None | No |
+| uuid          | An unique identifier for the layer | string | None | Yes |
 | name          | A given name for the layer. Must be unique amongst the layers. Can be any string without spaces | string | None | Yes |
 | function      | The function of layer. [See the list of potential functions below](#layer-functions-and-their-attributes) | string | None | Yes |
 | flexible      | True or false to indicate if this layer is flexible or not | boolean | None | No - default is "False" |

--- a/Products.md
+++ b/Products.md
@@ -127,8 +127,8 @@ The "processes" element type is an "array". Processes include everything which i
       "hole_type": through,
       "plated": false,
       "size": 0.15,
-      "layer_start": "conductive_layer_1",
-      "layer_stop": "conductive_layer_4",
+      "layer_start": "04c09da8-f6f1-4308-8822-b77363d34f9d",
+      "layer_stop": "05c10da8-f6f1-4308-8822-b77363d34f9d",
       "protection": "type4a"
     }
   }
@@ -160,8 +160,8 @@ Potential values are:
     * hole_type ( type is "string". Describes the type of hole. Choices are "through", "blind", "buried", "back_drill", "via")
     * finished_size ( type is "number". The finished size of the holes in micrometers )
     * tool_size ( type is "number". The size of the tool to be used in micrometers )
-    * layer_start ( type is "string". Must refer to the name of a layer in the layers section )
-    * layer_stop ( type is "string". Must refer to the name of a layer in the layers section )
+    * layer_start ( type is "string". Must refer to the uuid of a layer in the layers section )
+    * layer_stop ( type is "string". Must refer to the uuid of a layer in the layers section )
     * depth ( type is "number". Indicates the depth of the holes in micrometers )
     * method ( type is "string". How the via is made. Can be either "routing, "drilling" or "laser", where default is "drilling" )
     * minimum_designed_annular_ring ( type is "number". The minimum designed annular ring in micrometers )
@@ -248,7 +248,7 @@ Markings on the board can happen on several layers, including legends and solder
 
 | Tags          | Description           | [Type](/README.md#about-types-and-how-to-use-them) | Uom | Required |
 |:------------- |:----------------------|:----------------------------------------:|:---:|:--------:|
-| layers | List one or more layers by name that includes markings | Array of strings | None | No |
+| layers | List one or more layers by UUID that includes markings | Array of UUIDs | None | No |
 | date_code | Possible values are "YY" for year, "WW" for week "-" and "LOT" (alias "BATCH"). E.g. "YYWW-LOT" or "LOT-YYWW". If no marking, set "NONE" | String | None | No |
 | manufacturer_identification | Manufacturer identification | Boolean | None | No |
 | standards | Possible values are the ones listed in the subelement [standards](#standards) but typical will be "ul" and "rohs" | Array of strings | None | No |

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -756,7 +756,9 @@
   },
   "definitions": {
     "uuid": {
-      "type": "string"
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
     }
   }
 }

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -41,7 +41,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["none"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
@@ -59,7 +59,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["conductive"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -99,7 +99,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["dielectric"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -123,7 +123,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["soldermask"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -155,7 +155,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["stiffener"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -178,7 +178,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["plating"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -202,7 +202,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["adhesive"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -225,7 +225,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["thermal"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -248,7 +248,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["legend"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -279,7 +279,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["final_finish"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -316,7 +316,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["peelable_tape"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -339,7 +339,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["peelable_mask"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -371,7 +371,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["hard_gold"] },
             "sections": { "type": "array", "uniqueItems": true, "items": { "type": "string" } },
@@ -403,7 +403,7 @@
           "additionalProperties": false,
           "properties": {
             "order": { "type": "integer" },
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "name": { "type": "string" },
             "function": { "type": "string", "enum": ["solder_paste"] },
             "materials": { "type": "array", "uniqueItems": true, "items": { "type": "string" } }
@@ -420,7 +420,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["edge_bevelling"]
@@ -431,7 +431,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["depth_routing"]
@@ -442,7 +442,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["counterboring"]
@@ -453,7 +453,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["countersink"]
@@ -464,7 +464,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["punching"]
@@ -475,7 +475,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["plating"]
@@ -486,7 +486,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["plated_edges"]
@@ -497,7 +497,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["coin_attachment"]
@@ -508,7 +508,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "uuid": { "type": "string" },
+            "uuid": { "$ref": "#/definitions/uuid" },
             "function": {
               "type": "string",
               "enum": ["holes"]
@@ -752,6 +752,11 @@
           "resize_vias": { "type": "boolean" }
         }
       }
+    }
+  },
+  "definitions": {
+    "uuid": {
+      "type": "string"
     }
   }
 }

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -523,8 +523,8 @@
                   "enum": ["through", "blind", "buried", "back_drill", "via"]
                 },
                 "finished_size": { "type": "number", "uom": "μm"},
-                "layer_start": { "type": "string" },
-                "layer_stop": { "type": "string" },
+                "layer_start": { "$ref": "#/definitions/uuid" },
+                "layer_stop": { "$ref": "#/definitions/uuid" },
                 "depth": { "type": "number", "uom": "μm"},
                 "method": {
                   "type": "string",
@@ -648,7 +648,7 @@
           "layers": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/definitions/uuid"
             }
           },
           "date_code": { "type": "string" },

--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -35,6 +35,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections"
           ],
@@ -52,6 +53,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -92,6 +94,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -116,6 +119,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -148,6 +152,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -171,6 +176,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -195,6 +201,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -218,6 +225,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -241,6 +249,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -272,6 +281,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -309,6 +319,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -332,6 +343,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -364,6 +376,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "sections",
             "materials"
@@ -397,6 +410,7 @@
           "required": [
             "order",
             "name",
+            "uuid",
             "function",
             "materials"
           ],


### PR DESCRIPTION
This allows the layer and process names to be changed without needing to update the references that are used internally.