### PR TITLE
Add board area to metrics

### DIFF
--- a/schema/v1/ottp_circuitdata_schema_products.json
+++ b/schema/v1/ottp_circuitdata_schema_products.json
@@ -574,6 +574,7 @@
         "properties": {
           "size_x": { "type": "number", "uom": "mm" },
           "size_y": { "type": "number", "uom": "mm" },
+          "area": { "type": "number", "uom": "mm" },
           "breakaway_method": {
             "type": "string",
             "enum": ["routing", "punching"]


### PR DESCRIPTION
Without this information we do not know how to to calculate the area of copper in a layer accurately. We could use the width * height but it is not that often a square board.