### PR TITLE
Remove `v_cut` and `v_groove` from breakaway_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,5 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unneeded attributes from layers and processes.
 - Duplicate standard `ul`. This is the same as `ul94` and makes it consistent with how UL is named for materials.
 - Breakaway method from board. This is present and only makes sense in the array section where it describes how boards within an array are separated from each other and the array itself.
+- `v_cut` and `v_groove` from breakaway_method for array. These have the same meaning as `scoring` which is already present.
 
 ## [1.0.0] - 2018-03-12

--- a/schema/next/ottp_circuitdata_schema_products.json
+++ b/schema/next/ottp_circuitdata_schema_products.json
@@ -603,7 +603,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["routing", "scoring", "punching", "v_cut", "v_grove", "jump_scoring"]
+              "enum": ["routing", "scoring", "punching", "jump_scoring"]
             }
           },
           "mouse_bites": { "type": "boolean" },


### PR DESCRIPTION
Why: These options have the same meaning as `scoring` which is already present.