### PR TITLE
Remove duplicate standard UL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,5 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Unneeded attributes from layers and processes.
+- Duplicate standard `ul`. This is the same as `ul94` and makes it consistent with how UL is named for materials.
 
 ## [1.0.0] - 2018-03-12

--- a/schema/next/ottp_circuitdata_schema_products.json
+++ b/schema/next/ottp_circuitdata_schema_products.json
@@ -688,7 +688,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["ul", "c_ul", "rohs", "ul94", "iec_61249-2-21", "esa", "itar", "dfars", "mil_prf_55110", "mil_prf_50884", "mil_prf_31032", "as9100", "nadcap", "rw_en45545_2_2013", "rw_nf_f_16_101", "rw_uni_cei_11170_3", "rw_nfpa_130"]
+              "enum": ["ul94", "c_ul", "rohs", "iec_61249-2-21", "esa", "itar", "dfars", "mil_prf_55110", "mil_prf_50884", "mil_prf_31032", "as9100", "nadcap", "rw_en45545_2_2013", "rw_nf_f_16_101", "rw_uni_cei_11170_3", "rw_nfpa_130"]
             }
           },
           "ipc_6010_class": {


### PR DESCRIPTION
Why: We already have ul94 which is the same thing.

<!--
  Please remember to update the CHANGELOG with the contents of this PR.
-->
