### PR TITLE
Add IPC A600 to standards section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `solder_paste` as a valid layer function.
 - `additional`, `verified` and `ipc_standard` attributes to materials.
 - `capped` and `covered` to hole processes.
+- `ipc_a600_class` to standards section.
 
 ### Changed
 

--- a/schema/next/ottp_circuitdata_schema_products.json
+++ b/schema/next/ottp_circuitdata_schema_products.json
@@ -724,7 +724,11 @@
             "type": "string",
             "enum": ["1", "2", "3"]
           },
-          "ipc_6018": { "type": "boolean" }
+          "ipc_6018": { "type": "boolean" },
+          "ipc_a600_class": {
+            "type": "string",
+            "enum": ["1", "2", "3"]
+          }
         }
       },
       "testing": {


### PR DESCRIPTION
Why: So that boards can be specified to follow the A600 standard when delivered by a manufacturer.
