### PR TITLE
Add none option to impedance testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `additional`, `verified` and `ipc_standard` attributes to materials.
 - `capped` and `covered` to hole processes.
 - `ipc_a600_class` to standards section.
+- `none` option to impedance testing.
 
 ### Changed
 

--- a/schema/next/ottp_circuitdata_schema_products.json
+++ b/schema/next/ottp_circuitdata_schema_products.json
@@ -742,7 +742,7 @@
           "ist": { "type": "boolean" },
           "impedance": {
             "type": "string",
-            "enum": ["controlled", "calculated", "follow_stackup"]
+            "enum": ["controlled", "calculated", "follow_stackup", "none"]
           }
         }
       },


### PR DESCRIPTION
Why: So that there is a way to specify that impedance testing is not important.