### PR TITLE
Release - Prepare 2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+## [2.0.0] - 2019-04-08
+
+### Added
+
 - Document Versioning approach.
 - Realistic example files.
 - Board area to metrics section.

--- a/Materials.md
+++ b/Materials.md
@@ -9,7 +9,7 @@ Placed in the "open_trade_transfer_package -> custom -> materials -> circuitdata
   "circuitdata": {
     "osp": {
       "function": "final_finish",
-      "version": 1.0,
+      "version": 2.0,
       "group": "osp"
     }
   }

--- a/Profiles_and_Capabilities.md
+++ b/Profiles_and_Capabilities.md
@@ -20,7 +20,7 @@ Capabilities also contains a "materials" subsection where any capability on mate
 "profiles": {
   "enforced"
     "circuitdata": {
-      "version": 1.0,
+      "version": 2.0,
       "layers": {
         "soldermask": {
           "flexible": {
@@ -45,7 +45,7 @@ The example above would force Soldermask to be present two times (top and bottom
 "capabilities": {
   "summary"
     "circuitdata": {
-      "version": 1.0,
+      "version": 2.0,
       "layers": {
         "soldermask": {
           "count": 2

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open language for communicating specifications on a printed circuit (mainly P
 * A table of the structure of all objects, items and tags is [here](/Product_structure_table.md)
 
 ## Version
-Current version is 1.0. This should stated in every section directly below the "circuitdata" element in an element called "version".
+Current version is 2.0. This should stated in every section directly below the "circuitdata" element in an element called "version".
 
 ### Versioning
 CircuitData Language uses [semver](https://semver.org/). This means that we try our best to ensure that breaking changes mean a change in version number of the first component of the version.
@@ -50,7 +50,7 @@ JSON schema is available in at its [own site (schema.circuitdata.org)](http://sc
 ```
 ottp = '{
   "open_trade_transfer_package": {
-    "version": 1.0,
+    "version": 2.0,
     "information": {
       "company": "Elmatica as",
       "created": "2017-04-03T08:00:00Z"
@@ -59,7 +59,7 @@ ottp = '{
       "restricted": {
         "circuitdata": {
           "generic": {
-            "version": 1.0,
+            "version": 2.0,
             "country_of_origin": {
               "nato_member": false
             }

--- a/examples/ten_conductive_layers.json
+++ b/examples/ten_conductive_layers.json
@@ -1,6 +1,6 @@
 {
   "open_trade_transfer_package": {
-    "version": 1.0,
+    "version": 2.0,
     "products": {
       "ten_layer_1": {
         "circuitdata": {
@@ -577,7 +577,7 @@
               "area": 23040.0
             }
           },
-          "version": 1.0
+          "version": 2.0
         }
       }
     },
@@ -590,7 +590,7 @@
             "link": "http://www.piclaminate.com.cn/3-FL150_E.pdf",
             "remark": "R-F705T",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "soldermask",
             "group": "LPISM",
             "manufacturer": "PIC",
@@ -602,7 +602,7 @@
             "name": "FR4 min Tg140",
             "link": "http://www.rogerscorp.com/documents/728/acm/TMM-Thermoset-laminate-data-sheet-TMM3-TMM4-TMM6-TMM10-TMM10i.aspx",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "dielectric",
             "group": "FR4",
             "manufacturer": "Rogers",
@@ -618,7 +618,7 @@
             "link": "https://industrial.panasonic.com/content/data/EM/PDF/ipcdatasheet_1511_R-1755V.pdf",
             "remark": "no data",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "conductive",
             "group": "copper",
             "manufacturer": "Panasonic",

--- a/examples/testfile-all-elements.json
+++ b/examples/testfile-all-elements.json
@@ -1,6 +1,6 @@
 {
   "open_trade_transfer_package": {
-    "version": 1.0,
+    "version": 2.0,
     "information": {
       "company": "CircuitData Board of Directors",
       "created": "2018-02-15T09:49:37+02:00",
@@ -9,7 +9,7 @@
     "products": {
       "ProductX_v1": {
         "circuitdata": {
-          "version": 1.0,
+          "version": 2.0,
           "sections": [{
             "name": "rigid1",
             "in_x": [1],
@@ -39,7 +39,7 @@
       "materials": {
         "circuitdata": {
           "osp": {
-            "version": 1.0,
+            "version": 2.0,
             "function": "final_finish",
             "group": "osp"
           }

--- a/examples/testfile-profile-simple.json
+++ b/examples/testfile-profile-simple.json
@@ -1,6 +1,6 @@
 {
   "open_trade_transfer_package": {
-    "version": 1.0,
+    "version": 2.0,
     "information": {
       "company": "CircuitData Board of Directors",
       "created": "2018-02-15T09:49:37+02:00",
@@ -9,7 +9,7 @@
     "profiles": {
       "enforced": {
         "circuitdata": {
-          "version": 1.0,
+          "version": 2.0,
           "sections": {
             "count": 1,
             "mm2": 400

--- a/examples/two_conductive_layers.json
+++ b/examples/two_conductive_layers.json
@@ -1,6 +1,6 @@
 {
   "open_trade_transfer_package": {
-    "version": 1.0,
+    "version": 2.0,
     "products": {
       "two_conductive_layers": {
         "circuitdata": {
@@ -177,7 +177,7 @@
               "area": 1670.0
             }
           },
-          "version": 1.0
+          "version": 2.0
         }
       }
     },
@@ -190,7 +190,7 @@
             "link": "http://www.piclaminate.com.cn/3-FL150_E.pdf",
             "remark": "R-F705T",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "soldermask",
             "group": "LPISM",
             "manufacturer": "PIC",
@@ -202,7 +202,7 @@
             "name": "FR4 min Tg140",
             "link": "http://www.rogerscorp.com/documents/728/acm/TMM-Thermoset-laminate-data-sheet-TMM3-TMM4-TMM6-TMM10-TMM10i.aspx",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "dielectric",
             "group": "FR4",
             "manufacturer": "Rogers",
@@ -218,7 +218,7 @@
             "link": "https://industrial.panasonic.com/content/data/EM/PDF/ipcdatasheet_1511_R-1755V.pdf",
             "remark": "no data",
             "flexible": false,
-            "version": 1.0,
+            "version": 2.0,
             "function": "conductive",
             "group": "copper",
             "manufacturer": "Panasonic",

--- a/schema/next/ottp_circuitdata_schema.json
+++ b/schema/next/ottp_circuitdata_schema.json
@@ -10,8 +10,8 @@
       "properties": {
         "version": {
           "type": "number",
-          "minimum": 1,
-          "maximum": 2
+          "minimum": 2,
+          "maximum": 3
         },
         "information": {
           "$ref": "https://raw.githubusercontent.com/elmatica/Open-Trade-Transfer-Package/master/v1/ottp_schema_definitions.json#/definitions/information"

--- a/schema/next/ottp_circuitdata_schema_generics.json
+++ b/schema/next/ottp_circuitdata_schema_generics.json
@@ -1,8 +1,8 @@
 {
   "version": {
     "type": "number",
-    "minimum": 1,
-    "maximum": 2
+    "minimum": 2,
+    "maximum": 3
   },
   "profile_capability_layer_subelement": {
     "type": "object",


### PR DESCRIPTION
Time for a release! There are quite a number of changes to this version and looking at the changes I can only see this as being a breaking change for folks on 1.0.

Here is the accompanying release announcement that will be posted to the forum (formatting will be tweaked, feel free to edit):

```md
Hi everyone,

Today we are releasing the latest version of CircuitData Language as 2.0. 
This is in line with the release schedule which is to release on a quarterly basis.

There are quite a number of changes in the release. What follows is a high 
level overview of what has changed since 1.0. For a more detailed breakdown 
see the [changelog](https://github.com/CircuitData/CircuitData-Language/blob/master/CHANGELOG.md).

## General changes:
- Versioning for the language has been [documented](https://github.com/CircuitData/CircuitData-Language#versioning).
- Realistic [example files](https://github.com/CircuitData/CircuitData-Language/tree/master/examples) have been added.
- Spelling mistakes for some property names have been fixed.


## Changes related to products
- Made `layer_attributes` specific to the layer function.
- Added five new attributes. Also removed a number of properties that were not needed.
- Added UoM to relevant properties.
- Limited number of materials to one except for final finish layers.
- Renamed a number of attributes to match how the terms are used in industry.
- Removed duplicate options for properties. For example v_cut and v_groove.
- Changed IPC 6010 properties to be less generic and match what folks expect.

## Changes related to materials

- Added three new attributes.
- Extended ipc_slash_sheet to allow for multiple slash sheets.
- Add some missing groups.

```