### PR TITLE
Rename soldermask semi_glossy to semi_matte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Renamed soldermask finish option `semi_glossy` to `semi_matte`.
 
 ### Deprecated
 

--- a/schema/next/ottp_circuitdata_schema_materials.json
+++ b/schema/next/ottp_circuitdata_schema_materials.json
@@ -90,7 +90,7 @@
           },
           "finish": {
             "type": "string",
-            "enum": ["matte", "glossy", "semi_glossy"]
+            "enum": ["matte", "glossy", "semi_matte"]
           }
         }
       }


### PR DESCRIPTION
Why: So that we are inline with the most commonly used term in industry.

<!--
  Please remember to update the CHANGELOG with the contents of this PR.
-->
