### PR TITLE
Feature - Add peelable soldermask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Units of Measure to material schema.
 - Standards from IPC 4103 for laminates ("PTFE/None", "PTFE/Ceramic", "Hydrocarbon/None", "Hydrocarbon/Ceramic").
+- Peelable soldermasks
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Units of Measure to material schema.
 - Standards from IPC 4103 for laminates ("PTFE/None", "PTFE/Ceramic", "Hydrocarbon/None", "Hydrocarbon/Ceramic").
-- Peelable soldermasks
+- Ability to define materials as having the peelable_mask function.
 
 ### Changed
 

--- a/schema/next/ottp_circuitdata_schema_materials.json
+++ b/schema/next/ottp_circuitdata_schema_materials.json
@@ -72,7 +72,8 @@
           "PTFE/None",
           "PTFE/Ceramic",
           "Hydrocarbon/None",
-          "Hydrocarbon/Ceramic"
+          "Hydrocarbon/Ceramic",
+          "peelable"
         ]
       },
       "manufacturer": { "type": "string" },

--- a/schema/next/ottp_circuitdata_schema_materials.json
+++ b/schema/next/ottp_circuitdata_schema_materials.json
@@ -14,7 +14,8 @@
           "dielectric",
           "soldermask",
           "stiffener",
-          "final_finish"
+          "final_finish",
+          "peelable_mask"
         ]
       },
       "group": {
@@ -72,8 +73,7 @@
           "PTFE/None",
           "PTFE/Ceramic",
           "Hydrocarbon/None",
-          "Hydrocarbon/Ceramic",
-          "peelable"
+          "Hydrocarbon/Ceramic"
         ]
       },
       "manufacturer": { "type": "string" },


### PR DESCRIPTION
Why: Peelable soldermasks are temporary masks that can easily be removed.


<!--
  Please remember to update the CHANGELOG with the contents of this PR.
-->